### PR TITLE
try old cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10.2)
 project(livox_sdk)
 
 # C++ config.


### PR DESCRIPTION
This means that we can build the Livox-SDK in Ubuntu 18.04 without having to install a newer cmake version.